### PR TITLE
STAR-11121 Add support for restore jobs

### DIFF
--- a/moto/moto_api/_internal/models.py
+++ b/moto/moto_api/_internal/models.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, List, Optional, Set, Tuple
 
+from moto.core.exceptions import RESTError
+
 from moto.core import DEFAULT_ACCOUNT_ID
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.config import default_user_config
@@ -175,6 +177,19 @@ class MotoAPIBackend(BaseBackend):
             default_user_config["lambda"] = config["lambda"]
         if "stepfunctions" in config:
             default_user_config["stepfunctions"] = config["stepfunctions"]
+
+    def configure_s3control(self, config: Dict[str, Any]):
+        restoration_delay_in_seconds = config.get("restoration_delay_in_seconds")
+        if restoration_delay_in_seconds is not None:
+            try:
+                from moto.s3control.jobs import set_restoration_delay
+
+                set_restoration_delay(int(restoration_delay_in_seconds))
+            except ValueError:
+                raise RESTError(
+                    "InvalidParameterValue",
+                    f"restoration_delay_in_seconds must be an integer, given {restoration_delay_in_seconds}",
+                )
 
 
 moto_api_backend = MotoAPIBackend(region_name="global", account_id=DEFAULT_ACCOUNT_ID)

--- a/moto/moto_api/_internal/responses.py
+++ b/moto/moto_api/_internal/responses.py
@@ -375,6 +375,19 @@ class MotoAPIResponse(BaseResponse):
         config = moto_api_backend.get_config()
         return 201, res_headers, json.dumps(config).encode("utf-8")
 
+    def configure_s3control(
+        self,
+        request: Any,
+        full_url: str,  # pylint: disable=unused-argument
+        headers: Any,
+    ) -> TYPE_RESPONSE:
+        from .models import moto_api_backend
+
+        body = self._get_body(headers, request)
+
+        moto_api_backend.configure_s3control(body)
+        return 201, {}, ""
+
     def _get_body(self, headers: Any, request: Any) -> Any:
         if isinstance(request, AWSPreparedRequest):
             return json.loads(request.body)  # type: ignore[arg-type]

--- a/moto/moto_api/_internal/urls.py
+++ b/moto/moto_api/_internal/urls.py
@@ -26,6 +26,7 @@ url_paths = {
     "{0}/moto-api/state-manager/get-transition": response_instance.get_transition,
     "{0}/moto-api/state-manager/set-transition": response_instance.set_transition,
     "{0}/moto-api/state-manager/unset-transition": response_instance.unset_transition,
+    "{0}/moto-api/s3control/configure": response_instance.configure_s3control,
     "{0}/moto-api/recorder/reset-recording": recorder_response.reset_recording,
     "{0}/moto-api/recorder/start-recording": recorder_response.start_recording,
     "{0}/moto-api/recorder/stop-recording": recorder_response.stop_recording,

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -244,6 +244,7 @@ class FakeKey(BaseModel, ManagedState):
 
     def restore(self, days: int) -> None:
         self._expiry = utcnow() + datetime.timedelta(days)
+        self.status = "RESTORED"
         s3_backend = s3_backends[self.account_id][self.partition]
         bucket = s3_backend.get_bucket(self.bucket_name)  # type: ignore
         notifications.send_event(

--- a/moto/s3control/exceptions.py
+++ b/moto/s3control/exceptions.py
@@ -11,11 +11,16 @@ ERROR_WITH_ACCESS_POINT_POLICY = """{% extends 'wrapped_single_error' %}
 {% block extra %}<AccessPointName>{{ name }}</AccessPointName>{% endblock %}
 """
 
+ERROR_WITH_OPERATION_NAME = """{% extends 'wrapped_single_error' %}
+{% block extra %}<CreateJob>{{ name }}</CreateJob>{% endblock %}
+"""
+
 
 class S3ControlError(RESTError):
     extended_templates = {
         "ap_not_found": ERROR_WITH_ACCESS_POINT_NAME,
         "apf_not_found": ERROR_WITH_ACCESS_POINT_POLICY,
+        "operation_not_found": ERROR_WITH_OPERATION_NAME,
     }
     env = RESTError.extended_environment(extended_templates)
 
@@ -45,4 +50,26 @@ class AccessPointPolicyNotFound(S3ControlError):
             "NoSuchAccessPointPolicy",
             "The specified accesspoint policy does not exist",
             **kwargs,
+        )
+
+
+class ValidationError(S3ControlError):
+    pass
+
+
+class InvalidJobOperation(S3ControlError):
+    def __init__(self, name: str, **kwargs: Any):
+        kwargs.setdefault("template", "operation_not_found")
+        kwargs["name"] = name
+        super().__init__(
+            "BadRequestException", "The specified operation does not exist", **kwargs
+        )
+
+
+class JobNotFoundException(RESTError):
+    code = 400
+
+    def __init__(self):
+        super().__init__(
+            "InvalidRequest", "Job not found", template="wrapped_single_error"
         )

--- a/moto/s3control/jobs.py
+++ b/moto/s3control/jobs.py
@@ -1,0 +1,292 @@
+import csv
+import datetime
+import io
+import time
+import uuid
+from enum import Enum
+from threading import Thread
+from typing import Any, Dict, List, Optional, Tuple
+
+from moto.core.common_models import BaseModel
+from moto.moto_api._internal.managed_state_model import ManagedState
+from moto.s3.exceptions import MissingBucket
+
+from .exceptions import InvalidJobOperation, ValidationError
+
+restoration_delay_in_seconds = 60
+
+
+def set_restoration_delay(value_in_seconds):
+    global restoration_delay_in_seconds
+    restoration_delay_in_seconds = value_in_seconds
+
+
+def validate_job_status(target_job_status: str, valid_job_statuses: List[str]) -> None:
+    if target_job_status not in valid_job_statuses:
+        raise ValidationError(
+            (
+                "1 validation error detected: Value at 'current_status' failed "
+                "to satisfy constraint: Member must satisfy enum value set: {valid_statues}"
+            ).format(valid_statues=valid_job_statuses)
+        )
+
+
+# https://docs.aws.amazon.com/AmazonS3/latest/userguide/batch-ops-job-status.html
+class JobStatus(str, Enum):
+    ACTIVE = "Active"
+    CANCELLED = "Cancelled"
+    CANCELLING = "Cancelling"
+    COMPLETE = "Complete"
+    COMPLETING = "Completing"
+    FAILED = "Failed"
+    FAILING = "Failing"
+    NEW = "New"
+    PAUSED = "Paused"
+    PAUSING = "Pausing"
+    PREPARING = "Preparing"
+    READY = "Ready"
+    SUSPENDED = "Suspended"
+
+    @classmethod
+    def job_statuses(cls) -> List[str]:
+        return sorted([item.value for item in JobStatus])
+
+    @classmethod
+    def status_transitions(cls) -> List[Tuple[Optional[str], str]]:
+        return [
+            (JobStatus.NEW.value, JobStatus.PREPARING.value),
+            (JobStatus.PREPARING.value, JobStatus.SUSPENDED.value),
+            (JobStatus.SUSPENDED.value, JobStatus.READY.value),
+            (JobStatus.PREPARING.value, JobStatus.READY.value),
+            (JobStatus.READY.value, JobStatus.ACTIVE.value),
+            (JobStatus.PAUSING.value, JobStatus.PAUSED.value),
+            (JobStatus.CANCELLING.value, JobStatus.CANCELLED.value),
+            (JobStatus.FAILING.value, JobStatus.FAILED.value),
+            (JobStatus.ACTIVE.value, JobStatus.COMPLETE.value),
+        ]
+
+
+class JobDefinition:
+    def __init__(
+        self,
+        account_id: str,
+        partition: str,
+        operation_name: str,
+        operation_definition: Dict[str, Any],
+        params: Dict[str, Any],
+        manifest_arn: str,
+        manifest_etag: str | None,
+        manifest_format: str,
+        manifest_fields: str,
+        report_bucket: str | None,
+        report_enabled: bool,
+        report_format: str | None,
+        report_prefix: str | None,
+        report_scope: str | None,
+    ):
+        self.account_id = account_id
+        self.partition = partition
+        self.operation_name = operation_name
+        self.operation_definition = operation_definition
+        self.params = params
+        self.manifest_arn = manifest_arn
+        self.manifest_etag = manifest_etag
+        self.manifest_format = manifest_format
+        self.manifest_fields = manifest_fields
+        self.report_bucket = report_bucket
+        self.report_enabled = report_enabled
+        self.report_format = report_format
+        self.report_prefix = report_prefix
+        self.report_scope = report_scope
+
+    @classmethod
+    def from_dict(
+        cls, account_id: str, partition: str, params: Dict[str, Any]
+    ) -> "JobDefinition":
+        operation_tuple = list(params["Operation"].items())[0]
+        operation_name = operation_tuple[0]
+        operation_params = operation_tuple[1]
+        manifest = params["Manifest"]
+        manifest_location = manifest["Location"]
+        manifest_location_etag = manifest_location.get("ETag")
+        manifest_location_object_arn = manifest_location.get("ObjectArn")
+        manifest_spec = manifest["Spec"]
+        manifest_fields = manifest_spec["Fields"]
+        if isinstance(manifest_fields, dict) and "member" in manifest_fields:
+            manifest_fields = manifest_fields["member"]
+        manifest_format = manifest_spec["Format"]
+        report = params["Report"]
+        report_bucket = report.get("Bucket")
+        report_enabled = report.get("Enabled")
+        report_format = report.get("Format")
+        report_prefix = report.get("Prefix")
+        report_scope = report.get("ReportScope")
+        operation_definition = params["Operation"]
+        if report_enabled is not None:
+            report_enabled = report_enabled.lower() == "true"
+        return JobDefinition(
+            account_id=account_id,
+            partition=partition,
+            operation_name=operation_name,
+            operation_definition=operation_definition,
+            params=operation_params,
+            manifest_arn=manifest_location_object_arn,
+            manifest_etag=manifest_location_etag,
+            manifest_format=manifest_format,
+            manifest_fields=manifest_fields,
+            report_bucket=report_bucket,
+            report_enabled=report_enabled,
+            report_format=report_format,
+            report_prefix=report_prefix,
+            report_scope=report_scope,
+        )
+
+    @property
+    def manifest_bucket_name(self):
+        return self.manifest_arn.split("/")[0].split(":")[-1]
+
+    @property
+    def manifest_path(self):
+        return "/".join(self.manifest_arn.split("/")[1:])
+
+
+class Job(Thread, BaseModel, ManagedState):
+    def __init__(self, job_id, definition: JobDefinition):
+        Thread.__init__(self)
+        ManagedState.__init__(
+            self,
+            "s3control::job",
+            JobStatus.status_transitions(),
+        )
+
+        self.job_id = job_id
+        self.definition = definition
+        self.creation_time = datetime.datetime.now()
+        self.failure_reasons = []
+        self.stop = False
+        self.number_of_tasks_succeeded = 0
+        self.number_of_tasks_failed = 0
+        self.total_number_of_tasks = 0
+        self.elapsed_time_in_active_seconds = 0
+        self._bucket_index_in_csv = self.definition.manifest_fields.index("Bucket")
+        self._key_index_in_csv = self.definition.manifest_fields.index("Key")
+
+
+class RestoreObjectJob(Job):
+    def __init__(self, job_id, definition: JobDefinition):
+        super().__init__(job_id, definition)
+        self._expiration_days = 1
+        if "ExpirationInDays" in self.definition.operation_definition:
+            try:
+                self._expiration_days = int(
+                    self.definition.operation_definition["ExpirationInDays"]
+                )
+            except ValueError:
+                raise ValidationError("ExpirationInDays")
+
+    def run(self):
+        try:
+            self.status = JobStatus.PREPARING.value
+            succeeded = []
+            failed = []
+
+            from moto.s3.models import s3_backends
+
+            backend = s3_backends[self.definition.account_id][self.definition.partition]
+
+            manifest_file_obj = None
+            try:
+                manifest_file_obj = backend.get_object(
+                    self.definition.manifest_bucket_name, self.definition.manifest_path
+                )  # type: ignore[attr-defined]
+            except MissingBucket:
+                pass
+
+            if manifest_file_obj is None:
+                self.failure_reasons.append(
+                    {
+                        "code": "ManifestNotFound",
+                        "reason": "Manifest object was not found",
+                    }
+                )
+                self.status = JobStatus.FAILED.value
+                return
+
+            self.status = JobStatus.ACTIVE.value
+
+            expiration = datetime.datetime.now() + datetime.timedelta(
+                self._expiration_days, restoration_delay_in_seconds
+            )
+
+            for bucket, key in self._buckets_and_keys_from_csv(manifest_file_obj):
+                try:
+                    key_obj = backend.get_object(bucket, key)
+                except MissingBucket:
+                    continue
+                if key_obj is not None:
+                    key_obj.status = "IN_PROGRESS"
+                    key_obj.set_expiry(expiration)
+
+            self.status = JobStatus.COMPLETE.value
+
+            sleep_time = datetime.datetime.now() + datetime.timedelta(
+                0, restoration_delay_in_seconds
+            )
+            while datetime.datetime.now() < sleep_time:
+                time.sleep(0.5)
+                if self.stop:
+                    return
+
+            for bucket_and_key in self._buckets_and_keys_from_csv(manifest_file_obj):
+                try:
+                    key_obj = backend.get_object(*bucket_and_key)
+                except MissingBucket:
+                    failed.append(bucket_and_key)
+                    continue
+                if key_obj is not None:
+                    key_obj.restore(self._expiration_days)
+                    succeeded.append(bucket_and_key)
+                else:
+                    failed.append(bucket_and_key)
+        except Exception as exc:
+            print(f"Exception in job {self.job_id}: {exc}")  # noqa: T201
+
+    def _buckets_and_keys_from_csv(self, file_obj):
+        stream = io.StringIO(file_obj.value.decode(encoding="utf-8"))
+        for row in csv.reader(stream):
+            yield row[self._bucket_index_in_csv], row[self._key_index_in_csv]
+
+
+operation_to_job = {"S3InitiateRestoreObject": RestoreObjectJob}
+
+
+class JobsController:
+    def __init__(self):
+        self._jobs: Dict[str, Job] = {}
+
+    def stop(self):
+        for job in self._jobs.values():
+            if job.status not in (JobStatus.FAILED, JobStatus.COMPLETE):
+                job.stop = True
+                # Try to join
+                if job.is_alive():
+                    job.join(2)
+
+    def submit_job(
+        self, account_id: str, partition: str, params: Dict[str, Any]
+    ) -> str:
+        job_definition = JobDefinition.from_dict(account_id, partition, params)
+        job_class = operation_to_job.get(job_definition.operation_name)
+        if job_class is None:
+            raise InvalidJobOperation(
+                f"Unsupported operation: {job_definition.operation_name}"
+            )
+
+        job_id = str(uuid.uuid4())
+        job = job_class(job_id, job_definition)
+        self._jobs[job_id] = job
+        job.start()
+        return job_id
+
+    def get_job(self, job_id):
+        return self._jobs.get(job_id)

--- a/moto/s3control/responses.py
+++ b/moto/s3control/responses.py
@@ -7,6 +7,8 @@ from moto.core.common_types import TYPE_RESPONSE
 from moto.core.responses import BaseResponse
 from moto.s3.responses import S3_PUBLIC_ACCESS_BLOCK_CONFIGURATION
 
+from ..core.utils import iso_8601_datetime_without_milliseconds
+from .exceptions import InvalidJobOperation, JobNotFoundException
 from .models import S3ControlBackend, s3control_backends
 
 
@@ -61,6 +63,59 @@ class S3ControlResponse(BaseResponse):
         template = self.response_template(CREATE_ACCESS_POINT_TEMPLATE)
         return template.render(access_point=access_point)
 
+    def create_job(self) -> str:
+        account_id, _ = self._get_accountid_and_job_id_from_job(self.uri)
+        params = xmltodict.parse(self.body)["CreateJobRequest"]
+        job_id = self.backend.create_job(account_id=account_id, params=params)
+        template = self.response_template(CREATE_JOB_TEMPLATE)
+        return template.render(job_id=job_id)
+
+    def describe_job(self) -> str:
+        account_id, job_id = self._get_accountid_and_job_id_from_job(self.uri)
+        print(f"describe_job: {self.uri} -> {account_id=} {job_id=}\n")
+        job = self.backend.get_job(job_id=job_id)
+        if not job:
+            raise JobNotFoundException()
+
+        if job.definition.operation_name != "S3InitiateRestoreObject":
+            raise InvalidJobOperation(
+                f"Unsupported operation: {job.definition.operation_name}"
+            )
+
+        operation_template = self.response_template(
+            GET_JOB_INITIATE_S3_RESTORE_TEMPLATE
+        )
+        operation = operation_template.render(
+            expiration_in_days=job.definition.operation_definition.get(
+                "ExpirationInDays"
+            ),
+            glacier_job_tier=job.definition.operation_definition.get("GlacierJobTier"),
+        )
+
+        template = self.response_template(GET_JOB_TEMPLATE)
+        return template.render(
+            job_id=job_id,
+            account_id=account_id,
+            operation=operation,
+            creation_time=iso_8601_datetime_without_milliseconds(job.creation_time),
+            failure_reasons=job.failure_reasons,
+            region_name=self.backend.region_name,
+            manifest_etag=job.definition.manifest_etag,
+            manifest_object_arn=job.definition.manifest_arn,
+            manifest_format=job.definition.manifest_format,
+            manifest_fields=job.definition.manifest_fields,
+            number_of_tasks_failed=job.number_of_tasks_failed,
+            number_of_tasks_succeeded=job.number_of_tasks_succeeded,
+            elapsed_time_in_active_seconds=job.elapsed_time_in_active_seconds,
+            total_number_of_tasks=job.total_number_of_tasks,
+            report_bucket=job.definition.report_bucket,
+            report_enabled=job.definition.report_enabled,
+            report_format=job.definition.report_format,
+            report_prefix=job.definition.report_prefix,
+            report_scope=job.definition.report_scope,
+            status=job.status,
+        )
+
     def get_access_point(self) -> str:
         account_id, name = self._get_accountid_and_name_from_accesspoint(self.uri)
 
@@ -114,6 +169,14 @@ class S3ControlResponse(BaseResponse):
         account_id = url.split(".")[0]
         name = self.path.split("/")[-2]
         return account_id, name
+
+    def _get_accountid_and_job_id_from_job(self, full_url: str) -> Tuple[str, str]:
+        url = full_url
+        if full_url.startswith("http"):
+            url = full_url.split("://")[1]
+        account_id = url.split(".")[0]
+        job_id = url.split("v20180820/jobs/")[-1]
+        return account_id, job_id
 
 
 CREATE_ACCESS_POINT_TEMPLATE = """<CreateAccessPointResult>
@@ -186,4 +249,82 @@ GET_ACCESS_POINT_POLICY_STATUS_TEMPLATE = """<GetAccessPointPolicyResult>
       <IsPublic>true</IsPublic>
   </PolicyStatus>
 </GetAccessPointPolicyResult>
+"""
+
+
+CREATE_JOB_TEMPLATE = """<CreateJobResult>
+  <ResponseMetadata>
+    <RequestId>1549581b-12b7-11e3-895e-1334aEXAMPLE</RequestId>
+  </ResponseMetadata>
+   <JobId>{{ job_id }}</JobId>
+</CreateJobResult>
+"""
+
+
+GET_JOB_TEMPLATE = """
+<?xml version="1.0" encoding="UTF-8"?>
+<DescribeJobResult>
+  <Job>
+    <ConfirmationRequired>False</ConfirmationRequired>
+    <CreationTime>{{ creation_time }}</CreationTime>
+    <Description>Job description</Description>
+    <FailureReasons>
+    {% for failure_reason in failure_reasons %}
+      <JobFailure>
+        <FailureCode>{{ failure_reason["code"] }}</FailureCode>
+        <FailureReason>{{ failure_reason["reason"] }}</FailureReason>
+      </JobFailure>
+    {% endfor %}
+    </FailureReasons>
+    <JobArn>arn:aws:s3:{{ region_name }}:{{ account_id }}:job/{{ job_id }}</JobArn>
+    <JobId>{{ job_id }}</JobId>
+    <Manifest>
+      <Location>
+        <ETag>{{ manifest_etag }}</ETag>
+        <ObjectArn>{{ manifest_object_arn }}</ObjectArn>
+      </Location>
+      <Spec>
+        <Fields>
+          {% for manifest_field in manifest_fields %}
+            <member>{{ manifest_field }}</member>
+          {% endfor %}
+        </Fields>
+        <Format>{{ manifest_format }}</Format>
+      </Spec>
+    </Manifest>
+      <Operation>
+         {{ operation }}
+      </Operation>
+      <Priority>10</Priority>
+      <ProgressSummary>
+         <NumberOfTasksFailed>{{ number_of_tasks_failed }}</NumberOfTasksFailed>
+         <NumberOfTasksSucceeded>{{ number_of_tasks_succeeded }}</NumberOfTasksSucceeded>
+         <Timers>
+            <ElapsedTimeInActiveSeconds>{{ elapsed_time_in_active_seconds }}</ElapsedTimeInActiveSeconds>
+         </Timers>
+         <TotalNumberOfTasks>{{ total_number_of_tasks }}</TotalNumberOfTasks>
+      </ProgressSummary>
+      <Report>
+         <Bucket>{{ report_bucket }}</Bucket>
+         <Enabled>{{ report_enabled }}</Enabled>
+         <Format>{{ report_format }}</Format>
+         <Prefix>{{ report_prefix }}</Prefix>
+         <ReportScope>{{ report_scope }}</ReportScope>
+      </Report>
+      <RoleArn>arn:aws:iam::{{ account_id }}:role/s3batch-role</RoleArn>
+      <Status>{{ status }}</Status>
+   </Job>
+</DescribeJobResult>
+"""
+
+
+GET_JOB_INITIATE_S3_RESTORE_TEMPLATE = """
+<S3InitiateRestoreObject>
+  {% if expiration_in_days is not none %}
+    <ExpirationInDays>{{ expiration_in_days }}</ExpirationInDays>
+  {% endif %}
+  {% if glacier_job_tier is not none %}
+    <GlacierJobTier>{{ glacier_job_tier }}</GlacierJobTier>
+  {% endif %}
+</S3InitiateRestoreObject>
 """

--- a/moto/s3control/urls.py
+++ b/moto/s3control/urls.py
@@ -12,4 +12,6 @@ url_paths = {
     r"{0}/v20180820/accesspoint/(?P<name>[\w_:%-]+)$": S3ControlResponse.dispatch,
     r"{0}/v20180820/accesspoint/(?P<name>[\w_:%-]+)/policy$": S3ControlResponse.dispatch,
     r"{0}/v20180820/accesspoint/(?P<name>[\w_:%-]+)/policyStatus$": S3ControlResponse.dispatch,
+    r"{0}/v20180820/jobs$": S3ControlResponse.dispatch,
+    r"{0}/v20180820/jobs/(?P<job_id>[^/]+)$": S3ControlResponse.dispatch,
 }


### PR DESCRIPTION
This is a basic implementation of restore job.
It supports only selected set of jobs parameters,
for example, it does take into account priority,
different manifest formats. It does not generate report file at the end of the job. It does not check ETag of manifest. Tests are also not implemented.
Supported opertions:
- creating a job
- getting description of a job

It is possible to change delay time for restoration using the following endpoint from the internal API:

POST /moto-api/s3control/configure
{"restoration_delay_in_seconds": 123}